### PR TITLE
Fix: set_xlim for reactWidget

### DIFF
--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -529,7 +529,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         # Reset former xrange
         if former_xrange is not None:
-            self.condWidget.axes[0].set_xlim(former_xrange)
+            self.reactWidget.axes[0].set_xlim(former_xrange)
             
         self.reactWidget.axes[0].xaxis.set_major_formatter(TimeFormatter())
 


### PR DESCRIPTION
Looks like a typo while doing copy-paste.

Try to import data from directory (Ctrl+I) > switch to Reactions tab > plot reaction rate > plot another reaction rate
Exception window pop-ups with message:

An unhandled exception was raised: Traceback (most recent call last): 
File "qtplaskin/main.py", line 532, in update_react_graph self.condWidget.axes[0].set_xlim(former_xrange) 
IndexError: list index out of range 

As I can understand it we try to set xlim for condition graph, but we don't have any yet.
Unfortunately, I don't know how to write tests for PyQt, so I can't provide a proper testcase.