### PR TITLE
Fix: export data filename selection

### DIFF
--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -619,7 +619,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def export_data(self):
         """opens a file select dialog"""
         # open the dialog and get the selected file
-        fname = QtWidgets.QFileDialog.getSaveFileName(self, "Export data to file",
+        fname, _filter = QtWidgets.QFileDialog.getSaveFileName(self, "Export data to file",
                                                   ".",
                                                   "TSV files (*.tsv);;"
                                                   "TXT files (*.txt);;"

--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -521,7 +521,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def select_file(self):
         """opens a file select dialog"""
         # open the dialog and get the selected file
-        file = QtWidgets.QFileDialog.getOpenFileName(self, "Open data file",
+        file, *_rest = QtWidgets.QFileDialog.getOpenFileName(self, "Open data file",
                                                  ".",
                                                  "HDF5 files (*.h5 *.hdf5);;"
                                                  "All files (*)")
@@ -607,7 +607,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def save_to_file(self):
         """opens a file select dialog"""
         # open the dialog and get the selected file
-        fname = QtWidgets.QFileDialog.getSaveFileName(self, "Save to file",
+        fname, *_rest = QtWidgets.QFileDialog.getSaveFileName(self, "Save to file",
                                                   ".",
                                                   "HDF5 files (*.h5 *.hdf5);;"
                                                   "All files (*)")
@@ -619,7 +619,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def export_data(self):
         """opens a file select dialog"""
         # open the dialog and get the selected file
-        fname, _filter = QtWidgets.QFileDialog.getSaveFileName(self, "Export data to file",
+        fname, *_rest = QtWidgets.QFileDialog.getSaveFileName(self, "Export data to file",
                                                   ".",
                                                   "TSV files (*.tsv);;"
                                                   "TXT files (*.txt);;"


### PR DESCRIPTION
Hello @erwanp .
Looks like PyQt4 -> PyQt5 transition bug. 
Try to export data to file
File menu -> Export data... -> Chose filename in file selection dialog -> press Save button.
You  get exception 

An unhandled exception was raised: Traceback (most recent call last): 
File "./qtplaskin/main.py", line 633, in export_data .savedata(fname, self.location) 
File "./qtplaskin/mplwidget.py", line 233, in savedata with open(fname, "w") as fout: 
TypeError: expected str, bytes or os.PathLike object, not tuple 

QtWidgets.QFileDialog.getSaveFileName returns tuple, where filename is the first element
I found the following solution:
https://stackoverflow.com/questions/43509220/qtwidgets-qfiledialog-getopenfilename-returns-a-tuple

UPD:
Found two more instances of the same bug.
I suggest, the way I used  to unpack the first element of the tuple is more robust in case the function will return more than 2 elements in future . 
This syntax should work with all versions of  Python 3
https://www.python.org/dev/peps/pep-3132/ 