### PR TITLE
Update qtplaskin.modeldata to be more pythonic3 and fix minor visual bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.8"
 install:
   - sudo apt-get update
   # Install Anaconda 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: qtplaskin-env
 channels:
 - conda-forge
 dependencies:
-- python=3.6
+- python=3.8
 - numpy
 - scipy
 - matplotlib

--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -513,6 +513,7 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             name = item[1]
             rate = array(self.data.rate(item[0]))
 
+            rate = array([float(rat) for rat in rate])
             flt = rate > RATE_THRESHOLD
             label = "[%d] %s" % (item[0], name)
 

--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -26,14 +26,23 @@ import traceback
 try:
     from PyQt5 import QtGui, QtWidgets
 except ImportError:
-    raise ImportError('Warning. Qtplaskin was upgraded to PyQt5. You need to' +
-                      ' install PyQt5.')
+    try:  # conda install pyqt
+        import pyqt
+    except ImportError:
+        raise ImportError('Warning. Qtplaskin was upgraded to PyQt5. You need to' +
+                          ' install PyQt5.')
 
 # Qt5 bindings for core Qt functionalities (non-GUI)
-from PyQt5 import QtCore
+try:
+    from PyQt5 import QtCore
+except:   # conda install pyqt
+    from pyqt import QtCore
 
 # Python Qt5 bindings for GUI objects
-from PyQt5.QtCore import Qt
+try:
+    from PyQt5.QtCore import Qt
+except:  # conda install pyqt
+    from pyqt import QtCore
 
 from numpy import (array, zeros, nanmax, nanmin, where, isfinite,
                    argsort, r_, isreal, logical_and, float64, diff)
@@ -156,7 +165,8 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
                 output = []
                 # output.append(u't: {0:0.3e} s'.format(x))
-                output.append(TimeFormatter().simple_function(x, 0, number_after_decimals=3))
+                output.append(TimeFormatter().simple_function(
+                    x, 0, number_after_decimals=3))
                 output.append(u'y: {0:0.3e} {1}'.format(y, unit))
 
                 for key, val in zip(['z', 's'], [z, s]):
@@ -286,7 +296,8 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         else:  # autoscale to full range
             self.condWidget.axes[0].autoscale(True, axis='x')
 
-        self.condWidget.axes[0].xaxis.set_major_formatter(TimeFormatter().simple_function)
+        self.condWidget.axes[0].xaxis.set_major_formatter(
+            TimeFormatter().simple_function)
 
         # force an image redraw
         self.condWidget.draw()
@@ -348,7 +359,8 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         else:  # autoscale to full range
             self.densWidget.axes[0].autoscale(True, axis='x')
 
-        self.densWidget.axes[0].xaxis.set_major_formatter(TimeFormatter().simple_function)
+        self.densWidget.axes[0].xaxis.set_major_formatter(
+            TimeFormatter().simple_function)
 
         # force an image redraw
         self.densWidget.draw()
@@ -526,7 +538,8 @@ class DesignerMainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         if former_xrange is not None:
             self.reactWidget.axes[0].set_xlim(former_xrange)
 
-        self.reactWidget.axes[0].xaxis.set_major_formatter(TimeFormatter().simple_function)
+        self.reactWidget.axes[0].xaxis.set_major_formatter(
+            TimeFormatter().simple_function)
 
         # force an image redraw
         self.reactWidget.draw()

--- a/qtplaskin/main.py
+++ b/qtplaskin/main.py
@@ -27,7 +27,7 @@ try:
     from PyQt5 import QtGui, QtWidgets
 except ImportError:
     try:  # conda install pyqt
-        import pyqt
+        from pyqt import QtGui, QtWidgets
     except ImportError:
         raise ImportError('Warning. Qtplaskin was upgraded to PyQt5. You need to' +
                           ' install PyQt5.')

--- a/qtplaskin/mainwindow.py
+++ b/qtplaskin/mainwindow.py
@@ -10,7 +10,10 @@
 # Note: manually updated to PyQt5 on 29/10/16. mainwindow.ui not updated yet
 
 from qtplaskin.mplwidget import RatePlotWidget, SourcePlotWidget, ConditionsPlotWidget, DensityPlotWidget
-from PyQt5 import QtCore, QtGui, QtWidgets
+try:
+    from PyQt5 import QtCore, QtGui, QtWidgets
+except ImportError:  # conda install pyqt
+    from pyqt import QtCore, QtGui, QtWidgets
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8

--- a/qtplaskin/mplwidget.py
+++ b/qtplaskin/mplwidget.py
@@ -5,7 +5,10 @@ import numpy as np
 
 
 # Python Qt5 bindings for GUI objects
-from PyQt5 import QtGui, QtWidgets
+try:
+    from PyQt5 import QtGui, QtWidgets
+except ImportError:  # conda install pyqt
+    from pyqt import QtGui, QtWidgets
 
 # import the Qt5Agg FigureCanvas object, that binds Figure to
 # Qt5Agg backend. It also inherits from QWidget
@@ -144,7 +147,6 @@ class MplWidget(QtWidgets.QWidget):
 #        ydata = line.get_ydata()
 #
 #        return sum((xdata>=xmin) & (xdata<=xmax) & (ydata>=ymin) & (ydata<=ymax))
-
 
     def reset_lims(self):
         #    ax = plt.gca()

--- a/qtplaskin/timeformatter.py
+++ b/qtplaskin/timeformatter.py
@@ -49,5 +49,5 @@ class TimeFormatter(ScalarFormatter):
         elif time < 1:
             x_label = f"{time * 1e3:{precision}} ms"
         else:
-            x_label = f"{time:.2f} x_label"
+            x_label = f"{time:.2f} s"
         return x_label

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ import codecs
 try:
     import PyQt5
 except ImportError:
-    raise ImportError("Please install these librairies manually first (with Anaconda is "+\
+    try:
+        import pyqt
+    except ImportError:
+        raise ImportError("Please install these librairies manually first (with Anaconda is "+\
                         "strongly recommended) \n >>> conda install pyqt")
 
 long_description = 'A graphical tool to explore ZdPlaskin Results'

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -5,12 +5,12 @@ How to use?
 
 ZdPlaskin output files are not embedded in QtPlaskin, as they are very heavy
 
-You need to generate a first set of output files. Just run whatever case you 
+You need to generate a first set of output files. Just run whatever case you
 have available
 
 Then place it in a Results/ folder in qtplaskin/test
 
-Dont forget never to git these files 
+Dont forget never to git these files
 """
 
 import qtplaskin


### PR DESCRIPTION
- Add a `try import pyqt` everywhere `import pyqt5` was used, in order to be compatible with both `conda install pyqt` and `pip install pyqt5`
- in qtplaskin.modeldata, use python3 inheritance (`super().__init__()`) and use `Abstractclass` for `class ModelData`
- in qtplaskin.timeformatter, fix a minor visual bug (Instead of xxx s was displayed xxx x_label)