### PR TITLE
Fix deprecation of .basedir

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8
 - numpy
 - scipy
-- matplotlib
+- matplotlib>=3.4.3
 - pandas
 - h5py
 - pytest

--- a/qtplaskin/mplwidget.py
+++ b/qtplaskin/mplwidget.py
@@ -18,6 +18,7 @@ from matplotlib.backends.backend_qt5agg \
     import NavigationToolbar2QT as NavigationToolbar
 
 # Matplotlib Figure object
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
@@ -71,7 +72,7 @@ class VMToolbar(NavigationToolbar):
         # dirty hack to use exclusively .png and thus avoid .svg usage
         # because .exe generation is problematic with .svg
         name = name.replace('.svg', '.png')
-        return QtGui.QIcon(os.path.join(self.basedir, name))
+        return QtGui.QIcon(os.path.join(mpl.get_data_path(), "images", name))
 
 
 class MplWidget(QtWidgets.QWidget):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name='qtplaskin',
           'future',  # for builtins
           'numpy',
           'scipy',
-          'matplotlib',
+          'matplotlib>=3.4.3',
           'h5py',
           'mpldatacursor',
           'pandas>=1.0',


### PR DESCRIPTION
Fixed the deprecation message shown when running qtplaskin with matplotlib<=3.4.3
qtplaskin is now also compatible with matplotlib 3.5.2 (last version to the date).